### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           reporter: github-pr-review
           level: error
           filter_mode: file
-          fail_on_error: true
+          fail_level: any
       - name: check the exit code
         if: ${{ !success() }}
         run: echo 'The previous step should fail' && exit 1

--- a/README.md
+++ b/README.md
@@ -37,10 +37,19 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags.'

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,19 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags.'
@@ -52,6 +61,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_TYPOS_FLAGS: ${{ inputs.typos_flags }}

--- a/script.sh
+++ b/script.sh
@@ -25,6 +25,7 @@ typos ${INPUT_TYPOS_FLAGS} --format json |
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
+    -fail-level="${INPUT_FAIL_LEVEL}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     -tee \


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.